### PR TITLE
fix: launch shouldn't expand http uris

### DIFF
--- a/.execs/validate.flow
+++ b/.execs/validate.flow
@@ -50,7 +50,7 @@ executables:
             
             if [ "$CI" = "true" ]; then
               echo "Running golangci-lint with sarif output..."
-              golangci-lint run ./... --fix --output.sarif.path lint.sarif
+              golangci-lint run ./... --fix --output.sarif.path lint.sarif --output.text.path stdout
             else
               golangci-lint run ./... --fix
             fi

--- a/desktop/src-tauri/src/types/generated/flowfile.rs
+++ b/desktop/src-tauri/src/types/generated/flowfile.rs
@@ -682,11 +682,6 @@ impl ExecutableExecExecutableType {
 #[doc = "      \"description\": \"The URI to launch. This can be a file path or a web URL.\","]
 #[doc = "      \"default\": \"\","]
 #[doc = "      \"type\": \"string\""]
-#[doc = "    },"]
-#[doc = "    \"wait\": {"]
-#[doc = "      \"description\": \"If set to true, the executable will wait for the launched application to exit before continuing.\","]
-#[doc = "      \"default\": false,"]
-#[doc = "      \"type\": \"boolean\""]
 #[doc = "    }"]
 #[doc = "  }"]
 #[doc = "}"]
@@ -703,9 +698,6 @@ pub struct ExecutableLaunchExecutableType {
     pub params: ::std::option::Option<ExecutableParameterList>,
     #[doc = "The URI to launch. This can be a file path or a web URL."]
     pub uri: ::std::string::String,
-    #[doc = "If set to true, the executable will wait for the launched application to exit before continuing."]
-    #[serde(default)]
-    pub wait: bool,
 }
 impl ::std::convert::From<&ExecutableLaunchExecutableType> for ExecutableLaunchExecutableType {
     fn from(value: &ExecutableLaunchExecutableType) -> Self {
@@ -2831,7 +2823,6 @@ pub mod builder {
             ::std::string::String,
         >,
         uri: ::std::result::Result<::std::string::String, ::std::string::String>,
-        wait: ::std::result::Result<bool, ::std::string::String>,
     }
     impl ::std::default::Default for ExecutableLaunchExecutableType {
         fn default() -> Self {
@@ -2840,7 +2831,6 @@ pub mod builder {
                 args: Ok(Default::default()),
                 params: Ok(Default::default()),
                 uri: Err("no value supplied for uri".to_string()),
-                wait: Ok(Default::default()),
             }
         }
     }
@@ -2885,16 +2875,6 @@ pub mod builder {
                 .map_err(|e| format!("error converting supplied value for uri: {}", e));
             self
         }
-        pub fn wait<T>(mut self, value: T) -> Self
-        where
-            T: ::std::convert::TryInto<bool>,
-            T::Error: ::std::fmt::Display,
-        {
-            self.wait = value
-                .try_into()
-                .map_err(|e| format!("error converting supplied value for wait: {}", e));
-            self
-        }
     }
     impl ::std::convert::TryFrom<ExecutableLaunchExecutableType>
         for super::ExecutableLaunchExecutableType
@@ -2908,7 +2888,6 @@ pub mod builder {
                 args: value.args?,
                 params: value.params?,
                 uri: value.uri?,
-                wait: value.wait?,
             })
         }
     }
@@ -2921,7 +2900,6 @@ pub mod builder {
                 args: Ok(value.args),
                 params: Ok(value.params),
                 uri: Ok(value.uri),
-                wait: Ok(value.wait),
             }
         }
     }

--- a/desktop/src/pages/Executable/types/ExecutableLaunchDetails.tsx
+++ b/desktop/src/pages/Executable/types/ExecutableLaunchDetails.tsx
@@ -1,4 +1,4 @@
-import { Badge, Card, Code, Group, Stack, Text, Title } from "@mantine/core";
+import { Card, Code, Group, Stack, Text, Title } from "@mantine/core";
 import { IconExternalLink } from "@tabler/icons-react";
 import { EnrichedExecutable } from "../../../types/executable";
 
@@ -36,14 +36,6 @@ export function ExecutableLaunchDetails({
               >
                 {executable.launch.uri}
               </Text>
-            </div>
-          )}
-          {executable.launch?.wait && (
-            <div>
-              <Title order={5}>Wait:</Title>
-              <Badge variant="light" color="blue">
-                enabled
-              </Badge>
             </div>
           )}
         </Stack>

--- a/desktop/src/types/generated/flowfile.ts
+++ b/desktop/src/types/generated/flowfile.ts
@@ -356,10 +356,6 @@ export interface ExecutableLaunchExecutableType {
    * The URI to launch. This can be a file path or a web URL.
    */
   uri: string;
-  /**
-   * If set to true, the executable will wait for the launched application to exit before continuing.
-   */
-  wait?: boolean;
   [k: string]: unknown;
 }
 export interface ExecutableParallelExecutableType {

--- a/docs/schemas/flowfile_schema.json
+++ b/docs/schemas/flowfile_schema.json
@@ -195,11 +195,6 @@
           "description": "The URI to launch. This can be a file path or a web URL.",
           "type": "string",
           "default": ""
-        },
-        "wait": {
-          "description": "If set to true, the executable will wait for the launched application to exit before continuing.",
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/docs/types/flowfile.md
+++ b/docs/types/flowfile.md
@@ -172,7 +172,6 @@ Launches an application or opens a URI.
 | `args` |  | [ExecutableArgumentList](#ExecutableArgumentList) | <no value> |  |
 | `params` |  | [ExecutableParameterList](#ExecutableParameterList) | <no value> |  |
 | `uri` | The URI to launch. This can be a file path or a web URL. | `string` |  | ✘ |
-| `wait` | If set to true, the executable will wait for the launched application to exit before continuing. | `boolean` | false |  |
 
 ### ExecutableParallelExecutableType
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flowexec/flow
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
@@ -13,7 +13,6 @@ require (
 	github.com/flowexec/vault v0.1.2
 	github.com/gen2brain/beeep v0.11.1
 	github.com/jahvon/glamour v0.8.1-patch3
-	github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jahvon/glamour v0.8.1-patch3 h1:LfyMACZavV8yxK4UsPENNQQOqafWuq4ZdLuEAP2ZLE8=
 github.com/jahvon/glamour v0.8.1-patch3/go.mod h1:30MVJwG3rcEHrN277NrA4DKzndSL9lBtEmpcfOygwCQ=
-github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef h1:4PS/MNVT6Rsv15x5Rtwaw971e6kFvNUAf9nvUsZ5hcc=
-github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef/go.mod h1:dUmuT5CN6osIeLSRtTPJOf0Yz+qAbcyU6omnCzI+ZfQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/io/common/common.go
+++ b/internal/io/common/common.go
@@ -18,7 +18,7 @@ var termEditors = []string{"vim", "nvim", "emacs", "nano"}
 func OpenInEditor(path string, stdIn, stdOut *os.File) error {
 	preferred := os.Getenv("EDITOR")
 	if preferred != "" && !slices.Contains(termEditors, preferred) {
-		return open.OpenWith(preferred, path, false)
+		return open.OpenWith(preferred, path)
 	}
 	if preferred == "" {
 		preferred = "vim"

--- a/internal/io/library/update.go
+++ b/internal/io/library/update.go
@@ -123,7 +123,7 @@ func (l *Library) updateWsPane(msg tea.Msg) (viewport.Model, tea.Cmd) {
 				break
 			}
 
-			if err := open.Open(curWsCfg.Location(), false); err != nil {
+			if err := open.Open(curWsCfg.Location()); err != nil {
 				l.ctx.Logger.Error(err, "unable to open workspace")
 				l.SetNotice("unable to open workspace", themes.OutputLevelError)
 			}

--- a/internal/io/workspace/views.go
+++ b/internal/io/workspace/views.go
@@ -25,7 +25,7 @@ func NewWorkspaceView(
 		{
 			Key: "o", Label: "open",
 			Callback: func() error {
-				if err := open.Open(ws.Location(), false); err != nil {
+				if err := open.Open(ws.Location()); err != nil {
 					container.HandleError(fmt.Errorf("unable to open workspace: %w", err))
 				}
 				return nil

--- a/internal/runner/launch/launch.go
+++ b/internal/runner/launch/launch.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -51,16 +52,19 @@ func (r *launchRunner) Exec(
 		return errors.Wrap(err, "unable to set parameters to env")
 	}
 	launchSpec.URI = os.ExpandEnv(launchSpec.URI)
-	targetURI := utils.ExpandDirectory(
-		ctx.Logger,
-		launchSpec.URI,
-		e.WorkspacePath(),
-		e.FlowFilePath(),
-		envMap,
-	)
+	targetURI := launchSpec.URI
+	if !strings.HasPrefix(targetURI, "http") {
+		targetURI = utils.ExpandDirectory(
+			ctx.Logger,
+			launchSpec.URI,
+			e.WorkspacePath(),
+			e.FlowFilePath(),
+			envMap,
+		)
+	}
 
 	if launchSpec.App != "" {
-		return open.OpenWith(launchSpec.App, targetURI, launchSpec.Wait)
+		return open.OpenWith(launchSpec.App, targetURI)
 	}
-	return open.Open(targetURI, launchSpec.Wait)
+	return open.Open(targetURI)
 }

--- a/internal/services/open/exec.go
+++ b/internal/services/open/exec.go
@@ -1,0 +1,30 @@
+//go:build !windows && !darwin
+// +build !windows,!darwin
+
+package open
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func open(uri string) *exec.Cmd {
+	switch {
+	case os.Getenv(DisabledEnvKey) != "":
+		fmt.Println(fmt.Sprintf("xdg-open %s", uri))
+		return nil
+	default:
+		return exec.Command("xdg-open", uri)
+	}
+}
+
+func openWith(input string, appName string) *exec.Cmd {
+	switch {
+	case os.Getenv(DisabledEnvKey) != "":
+		fmt.Println(fmt.Sprintf("%s %s", appName, input))
+		return nil
+	default:
+		return exec.Command(appName, input)
+	}
+}

--- a/internal/services/open/exec.go
+++ b/internal/services/open/exec.go
@@ -12,7 +12,7 @@ import (
 func open(uri string) *exec.Cmd {
 	switch {
 	case os.Getenv(DisabledEnvKey) != "":
-		fmt.Println(fmt.Sprintf("xdg-open %s", uri))
+		fmt.Printf("xdg-open %s\n", uri)
 		return nil
 	default:
 		return exec.Command("xdg-open", uri)
@@ -22,7 +22,7 @@ func open(uri string) *exec.Cmd {
 func openWith(input string, appName string) *exec.Cmd {
 	switch {
 	case os.Getenv(DisabledEnvKey) != "":
-		fmt.Println(fmt.Sprintf("%s %s", appName, input))
+		fmt.Printf("%s %s\n", appName, input)
 		return nil
 	default:
 		return exec.Command(appName, input)

--- a/internal/services/open/exec_darwin.go
+++ b/internal/services/open/exec_darwin.go
@@ -1,0 +1,40 @@
+//go:build darwin
+// +build darwin
+
+package open
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func open(uri string) *exec.Cmd {
+	args := []string{uri}
+	if os.Getenv(BackgroundEnvKey) != "" {
+		args = append([]string{"-g"}, args...)
+	}
+	switch {
+	case os.Getenv(DisabledEnvKey) != "":
+		fmt.Printf("open %s\n", strings.Join(args, " "))
+		return nil
+	default:
+		return exec.Command("open", args...)
+	}
+}
+
+func openWith(uri string, appName string) *exec.Cmd {
+	args := []string{"-a", appName, uri}
+	if os.Getenv(BackgroundEnvKey) != "" {
+		args = append([]string{"-g"}, args...)
+	}
+
+	switch {
+	case os.Getenv(DisabledEnvKey) != "":
+		fmt.Printf("open %s\n", strings.Join(args, " "))
+		return nil
+	default:
+		return exec.Command("open", args...)
+	}
+}

--- a/internal/services/open/exec_windows.go
+++ b/internal/services/open/exec_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+// +build windows
+
+package open
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	// "syscall"
+)
+
+var (
+	cmd      = "url.dll,FileProtocolHandler"
+	runDll32 = filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe")
+)
+
+func cleaninput(input string) string {
+	r := strings.NewReplacer("&", "^&")
+	return r.Replace(input)
+}
+
+func open(input string) *exec.Cmd {
+	cmd := exec.Command(runDll32, cmd, input)
+	//cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}
+
+func openWith(input string, appName string) *exec.Cmd {
+	cmd := exec.Command("cmd", "/C", "start", "", appName, cleaninput(input))
+	//cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}

--- a/internal/services/open/open.go
+++ b/internal/services/open/open.go
@@ -1,33 +1,36 @@
 package open
 
 import (
-	"github.com/jahvon/open-golang/open"
-	"github.com/pkg/errors"
+	"fmt"
 )
 
-func Open(uri string, wait bool) error {
-	if wait {
-		if err := open.Run(uri); err != nil {
-			return errors.Wrap(err, "unable to open uri")
-		}
-	} else {
-		if err := open.Start(uri); err != nil {
-			return errors.Wrap(err, "unable to open uri")
-		}
-	}
+const (
+	BackgroundEnvKey = "OPEN_IN_BACKGROUND"
+	DisabledEnvKey   = "OPEN_DISABLED" // currently just used for simple smoke tests of the pkg
+)
 
+// Open a file, directory, or URI using the OS's default  application for that object type
+func Open(uri string) error {
+	cmd := open(uri)
+	if cmd == nil {
+		return nil
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w - unable to open uri: %s", err, output)
+	}
 	return nil
 }
 
-func OpenWith(appName, uri string, wait bool) error {
-	if wait {
-		if err := open.RunWith(uri, appName); err != nil {
-			return errors.Wrapf(err, "unable to open uri with %s", appName)
-		}
-	} else {
-		if err := open.StartWith(uri, appName); err != nil {
-			return errors.Wrapf(err, "unable to open uri with %s", appName)
-		}
+// OpenWith a file, directory, or URI using the specified application.
+func OpenWith(appName, uri string) error {
+	cmd := openWith(uri, appName)
+	if cmd == nil {
+		return nil
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w - unable to open uri with %s: %s", err, appName, output)
 	}
 	return nil
 }

--- a/internal/services/open/open_test.go
+++ b/internal/services/open/open_test.go
@@ -3,7 +3,6 @@ package open_test
 import (
 	"testing"
 
-	og "github.com/jahvon/open-golang/open"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -12,38 +11,20 @@ import (
 
 func TestOpen(t *testing.T) {
 	RegisterFailHandler(Fail)
-	t.Setenv(og.OpenDisabledEnvKey, "true")
+	t.Setenv(open.DisabledEnvKey, "true")
 	RunSpecs(t, "Open Suite")
 }
 
 var _ = Describe("Open", func() {
-	Context("when wait is true", func() {
-		It("should not return an error", func() {
-			err := open.Open("http://example.com", true)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Context("when wait is false", func() {
-		It("should not return an error", func() {
-			err := open.Open("http://example.com", false)
-			Expect(err).NotTo(HaveOccurred())
-		})
+	It("should not return an error", func() {
+		err := open.Open("http://example.com")
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 
 var _ = Describe("OpenWith", func() {
-	Context("when wait is true", func() {
-		It("should not return an error", func() {
-			err := open.OpenWith("firefox", "http://example.com", true)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Context("when wait is false", func() {
-		It("should not return an error", func() {
-			err := open.OpenWith("firefox", "http://example.com", false)
-			Expect(err).NotTo(HaveOccurred())
-		})
+	It("should not return an error", func() {
+		err := open.OpenWith("firefox", "http://example.com")
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/types/executable/executable.gen.go
+++ b/types/executable/executable.gen.go
@@ -180,10 +180,6 @@ type LaunchExecutableType struct {
 
 	// The URI to launch. This can be a file path or a web URL.
 	URI string `json:"uri" yaml:"uri" mapstructure:"uri"`
-
-	// If set to true, the executable will wait for the launched application to exit
-	// before continuing.
-	Wait bool `json:"wait,omitempty" yaml:"wait,omitempty" mapstructure:"wait,omitempty"`
 }
 
 type ParallelExecutableType struct {

--- a/types/executable/executable_md.go
+++ b/types/executable/executable_md.go
@@ -118,9 +118,6 @@ func launchExecMarkdown(e *ExecutableEnvironment, l *LaunchExecutableType) strin
 	if l.URI != "" {
 		mkdwn += fmt.Sprintf("**URI:** [%s](%s)\n", l.URI, l.URI)
 	}
-	if l.Wait {
-		mkdwn += "**Wait:** enabled\n"
-	}
 	mkdwn += execEnvTable(e)
 	return mkdwn
 }

--- a/types/executable/executable_schema.yaml
+++ b/types/executable/executable_schema.yaml
@@ -328,10 +328,6 @@ definitions:
         type: string
         description: The URI to launch. This can be a file path or a web URL.
         default: ""
-      wait:
-        type: boolean
-        description: If set to true, the executable will wait for the launched application to exit before continuing.
-        default: false
 
   ParallelRefConfig:
     type: object


### PR DESCRIPTION
Drops the useless `wait` option for launch execs, moves the logic into the flow codebase, and fixes an issue with launching http uris.