### PR TITLE
feat: add different icon for runnable execs in the library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/expr-lang/expr v1.17.5
-	github.com/flowexec/tuikit v0.2.0
+	github.com/flowexec/tuikit v0.2.1
 	github.com/flowexec/vault v0.1.2
 	github.com/gen2brain/beeep v0.11.1
 	github.com/jahvon/glamour v0.8.1-patch3

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/esiqveland/notify v0.13.3 h1:QCMw6o1n+6rl+oLUfg8P1IIDSFsDEb2WlXvVvIJb
 github.com/esiqveland/notify v0.13.3/go.mod h1:hesw/IRYTO0x99u1JPweAl4+5mwXJibQVUcP0Iu5ORE=
 github.com/expr-lang/expr v1.17.5 h1:i1WrMvcdLF249nSNlpQZN1S6NXuW9WaOfF5tPi3aw3k=
 github.com/expr-lang/expr v1.17.5/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/flowexec/tuikit v0.2.0 h1:VUceZWwWEbq4UtDtawb2ZbVeMR7ULDYQy4og5f4PKP4=
-github.com/flowexec/tuikit v0.2.0/go.mod h1:fjMwEM7FkxbP7bIV4CfEjsixgjicgQqPrejoBZAHf5s=
+github.com/flowexec/tuikit v0.2.1 h1:jsW5PrBiem4as3KWmhOB/7OS0LYB0voQnKXvAG0OsPU=
+github.com/flowexec/tuikit v0.2.1/go.mod h1:fjMwEM7FkxbP7bIV4CfEjsixgjicgQqPrejoBZAHf5s=
 github.com/flowexec/vault v0.1.2 h1:INQ/w81piKRM+zqPBQpxFYl1iK8dI3APIHZ1F1Jm7CA=
 github.com/flowexec/vault v0.1.2/go.mod h1:nxoGHIVjwSgg1o6DoTmj5NCJtubu71SvS883LPUXuvg=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jahvon/glamour"
 
 	"github.com/flowexec/flow/types/common"
+	"github.com/flowexec/flow/types/executable"
 	"github.com/flowexec/flow/types/workspace"
 )
 
@@ -172,7 +173,14 @@ func (l *Library) paneOneContent() string {
 	}
 	for i, ex := range l.visibleExecutables {
 		if uint(i) == l.currentExecutable {
-			sb.WriteString(renderSelection("* "+truncateText(shortRef(ex.Ref(), curWs, curNs), paneWidth), l.theme))
+			indicator := "*"
+			if (l.ctx.CurrentWorkspace != nil && ex.Workspace() == l.ctx.CurrentWorkspace.AssignedName()) ||
+				(ex.Visibility != nil && *ex.Visibility == executable.ExecutableVisibility(common.VisibilityPublic)) {
+				// indicate if runnable from the current ctx
+				indicator = "▶"
+			}
+			refStr := indicator + " " + truncateText(shortRef(ex.Ref(), curWs, curNs), paneWidth)
+			sb.WriteString(renderSelection(refStr, l.theme))
 		} else {
 			sb.WriteString(renderInactive("  "+truncateText(shortRef(ex.Ref(), curWs, curNs), paneWidth), l.theme))
 		}


### PR DESCRIPTION
Bumps tuikit to fix some post-run output issues and adds changes the icon that's used in the exec list for public executables / executables within the current ws. This should hopefully make it a bit clearer as to what can be run and what can't from the current context.