### PR TITLE
fix: expected flowfile extensions must have right suffix

### DIFF
--- a/types/executable/executables_test.go
+++ b/types/executable/executables_test.go
@@ -316,6 +316,7 @@ var _ = DescribeTable("HasFlowFileExt", func(file string, expected bool) {
 	Entry("ends with .flow", "development.flow", true),
 	Entry("ends with .flow.yaml", "development.flow.yaml", true),
 	Entry("ends with .flow.yml", "development.flow.yml", true),
+	Entry("ends with .flow + something else", "development.flow.txt", false),
 	Entry("ends with something else", "development.txt", false),
 )
 
@@ -326,5 +327,6 @@ var _ = DescribeTable("HasFlowFileTemplateExt", func(file string, expected bool)
 	Entry("ends with .flow.tmpl.yaml", "development.flow.tmpl.yaml", true),
 	Entry("ends with .flow.tmpl.yml", "development.flow.tmpl.yml", true),
 	Entry("ends with .flow", "development.flow", false),
+	Entry("ends with .flow.tmpl + something else", "development.flow.tmpl.txt", false),
 	Entry("ends with something else", "development.flow.txt", false),
 )

--- a/types/executable/flowfile.go
+++ b/types/executable/flowfile.go
@@ -13,7 +13,7 @@ import (
 
 const FlowFileExt = ".flow"
 
-var FlowFileExtRegex = regexp.MustCompile(fmt.Sprintf(`%s(\.yaml|\.yml)?`, regexp.QuoteMeta(FlowFileExt)))
+var FlowFileExtRegex = regexp.MustCompile(fmt.Sprintf(`%s(\.yaml|\.yml)?$`, regexp.QuoteMeta(FlowFileExt)))
 
 type FlowFileList []*FlowFile
 

--- a/types/executable/template.go
+++ b/types/executable/template.go
@@ -17,7 +17,7 @@ import (
 const FlowFileTemplateExt = ".flow.tmpl"
 
 //nolint:lll
-var FlowFileTemplateExtRegex = regexp.MustCompile(fmt.Sprintf(`%s(\.yaml|\.yml)?`, regexp.QuoteMeta(FlowFileTemplateExt)))
+var FlowFileTemplateExtRegex = regexp.MustCompile(fmt.Sprintf(`%s(\.yaml|\.yml)?$`, regexp.QuoteMeta(FlowFileTemplateExt)))
 
 type TemplateList []*Template
 


### PR DESCRIPTION
Fixes a small bug that was causing sync to pick up on files that ended with `.flow` + something else (i.e. `.flow.tmpl`)