### PR TITLE
fix: improve vault setup experience

### DIFF
--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -192,6 +192,13 @@ var ParameterValueFlag = &Metadata{
 	Default: []string{},
 }
 
+var VaultSetFlag = &Metadata{
+	Name:      "set",
+	Shorthand: "s",
+	Usage:     "Set the newly created vault as the current vault",
+	Default:   false,
+}
+
 var VaultTypeFlag = &Metadata{
 	Name:      "type",
 	Shorthand: "t",

--- a/cmd/internal/vault.go
+++ b/cmd/internal/vault.go
@@ -63,6 +63,7 @@ func registerCreateVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 
 	RegisterFlag(ctx, createCmd, *flags.VaultTypeFlag)
 	RegisterFlag(ctx, createCmd, *flags.VaultPathFlag)
+	RegisterFlag(ctx, createCmd, *flags.VaultSetFlag)
 	// AES flags
 	RegisterFlag(ctx, createCmd, *flags.VaultKeyEnvFlag)
 	RegisterFlag(ctx, createCmd, *flags.VaultKeyFileFlag)
@@ -80,6 +81,7 @@ func createVaultFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 	vaultName := args[0]
 	vaultType := flags.ValueFor[string](ctx, cmd, *flags.VaultTypeFlag, false)
 	vaultPath := flags.ValueFor[string](ctx, cmd, *flags.VaultPathFlag, false)
+	setVault := flags.ValueFor[bool](ctx, cmd, *flags.VaultSetFlag, false)
 
 	switch strings.ToLower(vaultType) {
 	case "aes256":
@@ -106,6 +108,10 @@ func createVaultFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 	)
 
 	ctx.Config.Vaults[vaultName] = vaultPath
+	if setVault {
+		ctx.Config.CurrentVault = &vaultName
+		logger.Infof("Vault '%s' set as current vault", vaultName)
+	}
 	if err := filesystem.WriteConfig(ctx.Config); err != nil {
 		logger.FatalErr(fmt.Errorf("unable to save user configuration: %w", err))
 	}

--- a/docs/cli/flow_vault_create.md
+++ b/docs/cli/flow_vault_create.md
@@ -16,6 +16,7 @@ flow vault create NAME [flags]
       --key-file string        File path for the vault encryption key. An absolute path is recommended. Only used for AES256 vaults.
   -p, --path string            Directory that the vault will use to store its data. If not set, the vault will be stored in the flow cache directory.
       --recipients string      Comma-separated list of recipient keys for the vault. Only used for Age vaults.
+  -s, --set                    Set the newly created vault as the current vault
   -t, --type string            Vault type. Either age or aes256 (default "aes256")
 ```
 

--- a/docs/guide/first-workflow.md
+++ b/docs/guide/first-workflow.md
@@ -91,11 +91,8 @@ You'll see each step run in sequence. This is your first multi-step workflow!
 Real deployments need configuration. Let's add some secrets:
 
 ```shell
-# Create a vault for this project
-flow vault create tutorial-vault
-
-# Set the generated key in the default environment variable
-export FLOW_VAULT_KEY="<key-from-output>"
+# Create a vault for this project and set the generated key in the default environment variable
+export FLOW_VAULT_KEY="$(flow vault create tutorial-vault --set --log-level fatal)"
 
 # Add some deployment secrets
 flow secret set server-url "https://my-server.com"

--- a/docs/guide/secrets.md
+++ b/docs/guide/secrets.md
@@ -8,8 +8,8 @@ Whether you're managing API keys, database passwords, or deployment tokens, the 
 Create your first vault and add a secret:
 
 ```shell
-# Create a vault (generates a key and shows it in output)
-flow vault create my-vault
+# Create a vault and set it as current (generates a key and shows it in output)
+flow vault create my-vault --set
 
 # Set the generated key in the default environment variable
 export FLOW_VAULT_KEY="<key-from-output>"
@@ -257,6 +257,8 @@ Switch between vaults for different projects or environments:
 
 ```shell
 # List all vaults
+# Authentication for the created vaults must be resolvable by the environment variable or file you
+# specified during vault creation in order to list them.
 flow vault list
 
 # Switch to a different vault

--- a/internal/io/vault/view.go
+++ b/internal/io/vault/view.go
@@ -63,8 +63,7 @@ func NewVaultView(
 ) tuikit.View {
 	v, err := vaultFromName(vaultName)
 	if err != nil || v == nil {
-		container.HandleError(fmt.Errorf("failed to load vault: %w", err))
-		return nil
+		return views.NewErrorView(err, container.RenderState().Theme)
 	}
 	return views.NewEntityView(container.RenderState(), v, types.EntityFormatDocument)
 }
@@ -116,17 +115,16 @@ func NewVaultListView(
 	vaults := &vaultCollection{Vaults: make([]*vaultEntity, 0, len(vaultNames))}
 	for _, name := range vaultNames {
 		v, err := vaultFromName(name)
-		if err != nil {
-			container.HandleError(fmt.Errorf("failed to load vault %s: %w", name, err))
-			continue
-		} else if v == nil {
-			continue
+		if err != nil || v == nil {
+			return views.NewErrorView(
+				fmt.Errorf("vault '%s' error: %w", name, err),
+				container.RenderState().Theme,
+			)
 		}
 		vaults.Vaults = append(vaults.Vaults, v)
 	}
 	if len(vaults.Vaults) == 0 {
-		container.HandleError(fmt.Errorf("no vaults found"))
-		return nil
+		return views.NewErrorView(fmt.Errorf("no vaults found"), container.RenderState().Theme)
 	}
 
 	selectFunc := func(filterVal string) error {

--- a/internal/vault/v2/vault.go
+++ b/internal/vault/v2/vault.go
@@ -75,7 +75,9 @@ func NewAES256Vault(logger io.Logger, name, storagePath, keyEnv, keyFile, logLev
 		logger.FatalErr(fmt.Errorf("unable to save vault config: %w", err))
 	}
 
-	logger.PlainTextSuccess(fmt.Sprintf("Vault '%s' with AES256 encryption created successfully", v.ID()))
+	if logLevel != "fatal" {
+		logger.PlainTextSuccess(fmt.Sprintf("Vault '%s' with AES256 encryption created successfully", v.ID()))
+	}
 }
 
 func generateAESKey(logger io.Logger, keyEnv, logLevel string) string {
@@ -93,7 +95,8 @@ func generateAESKey(logger io.Logger, keyEnv, logLevel string) string {
 		)
 		logger.PlainTextInfo(newKeyMsg)
 	} else {
-		logger.PlainTextSuccess(fmt.Sprintf("Encryption key: %s", key))
+		// just print the key without additional info
+		logger.Print(key)
 	}
 	return key
 }
@@ -173,7 +176,7 @@ func ConfigFilePath(vaultName string) string {
 
 func writeKeyToFile(logger io.Logger, key, filePath string) error {
 	if key == "" {
-		return fmt.Errorf("no key provided to write to file")
+		return nil
 	}
 	if filePath == "" {
 		return fmt.Errorf("no file path provided to write key")

--- a/tests/secret_cmds_e2e_test.go
+++ b/tests/secret_cmds_e2e_test.go
@@ -36,15 +36,12 @@ var _ = Describe("vault/secrets e2e", Ordered, func() {
 		It("should return the generated key", func() {
 			stdOut := ctx.StdOut()
 			keyEnv := "FLOW_TEST_VAULT_KEY"
-			Expect(run.Run(ctx.Context, "vault", "create", "test", "--key-env", keyEnv)).To(Succeed())
+			Expect(run.Run(ctx.Context, "vault", "create", "test", "--key-env", keyEnv, "--log-level", "fatal")).
+				To(Succeed())
 			out, err := readFileContent(stdOut)
 			Expect(err).NotTo(HaveOccurred())
 
-			lines := strings.Split(strings.TrimSpace(out), "\n")
-			Expect(lines).ToNot(BeEmpty())
-			parts := strings.Split(strings.TrimSpace(lines[0]), ":")
-			Expect(parts).To(HaveLen(2))
-			encryptionKey := strings.TrimSpace(parts[1])
+			encryptionKey := strings.TrimSpace(strings.TrimSpace(out))
 			Expect(os.Setenv(keyEnv, encryptionKey)).To(Succeed())
 		})
 


### PR DESCRIPTION
A variety of changes that improves the experience of creating a vault. Includes the `--set` flag, a clean way of getting the generated token, and some docs updates 