### PR TITLE
feat: add support for env files at ws and exec level

### DIFF
--- a/desktop/src-tauri/src/types/generated/flowfile.rs
+++ b/desktop/src-tauri/src/types/generated/flowfile.rs
@@ -944,8 +944,13 @@ impl ::std::convert::From<::std::vec::Vec<ExecutableParallelRefConfig>>
 #[doc = "  \"description\": \"A parameter is a value that can be passed to an executable and all of its sub-executables.\\nOnly one of `text`, `secretRef`, `prompt`, or `file` must be set. Specifying more than one will result in an error.\\n\","]
 #[doc = "  \"type\": \"object\","]
 #[doc = "  \"properties\": {"]
+#[doc = "    \"envFile\": {"]
+#[doc = "      \"description\": \"A path to a file containing environment variables to be passed to the executable.\\nThe file should contain one variable per line in the format `KEY=VALUE`.\\n\","]
+#[doc = "      \"default\": \"\","]
+#[doc = "      \"type\": \"string\""]
+#[doc = "    },"]
 #[doc = "    \"envKey\": {"]
-#[doc = "      \"description\": \"The name of the environment variable that will be assigned the value.\","]
+#[doc = "      \"description\": \"The name of the environment variable that will be assigned the value.\\n\\nWhen specified with `envFile`, only the environment variable with this name will be set.\\n\","]
 #[doc = "      \"default\": \"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
@@ -975,7 +980,10 @@ impl ::std::convert::From<::std::vec::Vec<ExecutableParallelRefConfig>>
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 pub struct ExecutableParameter {
-    #[doc = "The name of the environment variable that will be assigned the value."]
+    #[doc = "A path to a file containing environment variables to be passed to the executable.\nThe file should contain one variable per line in the format `KEY=VALUE`.\n"]
+    #[serde(rename = "envFile", default)]
+    pub env_file: ::std::string::String,
+    #[doc = "The name of the environment variable that will be assigned the value.\n\nWhen specified with `envFile`, only the environment variable with this name will be set.\n"]
     #[serde(rename = "envKey", default)]
     pub env_key: ::std::string::String,
     #[doc = "A path where the parameter value will be temporarily written to disk.\nThe file will be created before execution and cleaned up afterwards.\n"]
@@ -999,6 +1007,7 @@ impl ::std::convert::From<&ExecutableParameter> for ExecutableParameter {
 impl ::std::default::Default for ExecutableParameter {
     fn default() -> Self {
         Self {
+            env_file: Default::default(),
             env_key: Default::default(),
             output_file: Default::default(),
             prompt: Default::default(),
@@ -3468,6 +3477,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct ExecutableParameter {
+        env_file: ::std::result::Result<::std::string::String, ::std::string::String>,
         env_key: ::std::result::Result<::std::string::String, ::std::string::String>,
         output_file: ::std::result::Result<::std::string::String, ::std::string::String>,
         prompt: ::std::result::Result<::std::string::String, ::std::string::String>,
@@ -3477,6 +3487,7 @@ pub mod builder {
     impl ::std::default::Default for ExecutableParameter {
         fn default() -> Self {
             Self {
+                env_file: Ok(Default::default()),
                 env_key: Ok(Default::default()),
                 output_file: Ok(Default::default()),
                 prompt: Ok(Default::default()),
@@ -3486,6 +3497,16 @@ pub mod builder {
         }
     }
     impl ExecutableParameter {
+        pub fn env_file<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::string::String>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.env_file = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for env_file: {}", e));
+            self
+        }
         pub fn env_key<T>(mut self, value: T) -> Self
         where
             T: ::std::convert::TryInto<::std::string::String>,
@@ -3543,6 +3564,7 @@ pub mod builder {
             value: ExecutableParameter,
         ) -> ::std::result::Result<Self, super::error::ConversionError> {
             Ok(Self {
+                env_file: value.env_file?,
                 env_key: value.env_key?,
                 output_file: value.output_file?,
                 prompt: value.prompt?,
@@ -3554,6 +3576,7 @@ pub mod builder {
     impl ::std::convert::From<super::ExecutableParameter> for ExecutableParameter {
         fn from(value: super::ExecutableParameter) -> Self {
             Self {
+                env_file: Ok(value.env_file),
                 env_key: Ok(value.env_key),
                 output_file: Ok(value.output_file),
                 prompt: Ok(value.prompt),

--- a/desktop/src-tauri/src/types/generated/workspace.rs
+++ b/desktop/src-tauri/src/types/generated/workspace.rs
@@ -206,6 +206,14 @@ impl
 #[doc = "      \"default\": \"\","]
 #[doc = "      \"type\": \"string\""]
 #[doc = "    },"]
+#[doc = "    \"envFiles\": {"]
+#[doc = "      \"description\": \"A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables.\\nBy default, the `.env` file in the workspace root is loaded if it exists.\\n\","]
+#[doc = "      \"default\": [],"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"type\": \"string\""]
+#[doc = "      }"]
+#[doc = "    },"]
 #[doc = "    \"executables\": {"]
 #[doc = "      \"$ref\": \"#/definitions/ExecutableFilter\""]
 #[doc = "    },"]
@@ -231,6 +239,13 @@ pub struct Workspace {
     #[doc = "The display name of the workspace. This is used in the interactive UI."]
     #[serde(rename = "displayName", default)]
     pub display_name: ::std::string::String,
+    #[doc = "A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables.\nBy default, the `.env` file in the workspace root is loaded if it exists.\n"]
+    #[serde(
+        rename = "envFiles",
+        default,
+        skip_serializing_if = "::std::vec::Vec::is_empty"
+    )]
+    pub env_files: ::std::vec::Vec<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub executables: ::std::option::Option<ExecutableFilter>,
     #[serde(default = "defaults::workspace_tags")]
@@ -253,6 +268,7 @@ impl ::std::default::Default for Workspace {
             description: Default::default(),
             description_file: Default::default(),
             display_name: Default::default(),
+            env_files: Default::default(),
             executables: Default::default(),
             tags: defaults::workspace_tags(),
             verb_aliases: Default::default(),
@@ -327,6 +343,8 @@ pub mod builder {
         description: ::std::result::Result<::std::string::String, ::std::string::String>,
         description_file: ::std::result::Result<::std::string::String, ::std::string::String>,
         display_name: ::std::result::Result<::std::string::String, ::std::string::String>,
+        env_files:
+            ::std::result::Result<::std::vec::Vec<::std::string::String>, ::std::string::String>,
         executables: ::std::result::Result<
             ::std::option::Option<super::ExecutableFilter>,
             ::std::string::String,
@@ -341,6 +359,7 @@ pub mod builder {
                 description: Ok(Default::default()),
                 description_file: Ok(Default::default()),
                 display_name: Ok(Default::default()),
+                env_files: Ok(Default::default()),
                 executables: Ok(Default::default()),
                 tags: Ok(super::defaults::workspace_tags()),
                 verb_aliases: Ok(Default::default()),
@@ -379,6 +398,16 @@ pub mod builder {
             self.display_name = value
                 .try_into()
                 .map_err(|e| format!("error converting supplied value for display_name: {}", e));
+            self
+        }
+        pub fn env_files<T>(mut self, value: T) -> Self
+        where
+            T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+            T::Error: ::std::fmt::Display,
+        {
+            self.env_files = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for env_files: {}", e));
             self
         }
         pub fn executables<T>(mut self, value: T) -> Self
@@ -421,6 +450,7 @@ pub mod builder {
                 description: value.description?,
                 description_file: value.description_file?,
                 display_name: value.display_name?,
+                env_files: value.env_files?,
                 executables: value.executables?,
                 tags: value.tags?,
                 verb_aliases: value.verb_aliases?,
@@ -433,6 +463,7 @@ pub mod builder {
                 description: Ok(value.description),
                 description_file: Ok(value.description_file),
                 display_name: Ok(value.display_name),
+                env_files: Ok(value.env_files),
                 executables: Ok(value.executables),
                 tags: Ok(value.tags),
                 verb_aliases: Ok(value.verb_aliases),

--- a/desktop/src/types/generated/flowfile.ts
+++ b/desktop/src/types/generated/flowfile.ts
@@ -366,7 +366,16 @@ export interface ExecutableArgument {
  */
 export interface ExecutableParameter {
   /**
+   * A path to a file containing environment variables to be passed to the executable.
+   * The file should contain one variable per line in the format `KEY=VALUE`.
+   *
+   */
+  envFile?: string;
+  /**
    * The name of the environment variable that will be assigned the value.
+   *
+   * When specified with `envFile`, only the environment variable with this name will be set.
+   *
    */
   envKey?: string;
   /**

--- a/desktop/src/types/generated/workspace.ts
+++ b/desktop/src/types/generated/workspace.ts
@@ -29,6 +29,12 @@ export interface Workspace {
    * The display name of the workspace. This is used in the interactive UI.
    */
   displayName?: string;
+  /**
+   * A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables.
+   * By default, the `.env` file in the workspace root is loaded if it exists.
+   *
+   */
+  envFiles?: string[];
   executables?: ExecutableFilter;
   tags?: CommonTags;
   verbAliases?: VerbAliases;

--- a/docs/guide/executables.md
+++ b/docs/guide/executables.md
@@ -61,6 +61,12 @@ executables:
 
 Customize executable behavior with environment variables or temporary files using `params` or `args`.
 
+> [!INFO]
+> Executables inherit environment variables from their parent executable, workspace, and system.
+> 
+> By default, values defined in the `.env` file at the workspace root are automatically loaded. This can be overriden
+> in the workspace configuration file with the `envFiles` field.
+
 ### Parameters (`params`) <!-- {docsify-ignore} -->
 
 Set environment data from various sources:
@@ -85,6 +91,11 @@ executables:
         # Static values
         - text: "production"
           envKey: DEPLOY_ENV
+          
+        # Env File (key=value format)
+        - envFile: "development.env"
+        - envFile: "staging.env"
+          envKey: SHARED_KEYS  # Only load specific keys
 
         # Saved to a file
         - secretRef: tls-cert
@@ -95,6 +106,7 @@ executables:
 - `secretRef`: Reference to vault secret
 - `prompt`: Interactive user input
 - `text`: Static value
+- `envFile`: Load environment variables from a file
 
 ### Arguments (`args`) <!-- {docsify-ignore} -->
 

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -79,6 +79,11 @@ verbAliases:
   run: ["start", "exec"]
   build: ["compile", "make"]
   # Set to {} to disable all aliases
+  
+# Environment variables to load for all executables in this workspace
+envFiles:
+  - .env
+  - .env.local
 
 # Control executable discovery
 executables:
@@ -100,6 +105,7 @@ executables:
 
 **Behavior Customization:**
 - `verbAliases`: Customize which verb synonyms are available
+- `envFiles`: List of environment files to load for all executables (the root `.env` is loaded by default)
 
 > **Complete reference**: See the [workspace configuration schema](../types/workspace.md) for all available options.
 

--- a/docs/schemas/flowfile_schema.json
+++ b/docs/schemas/flowfile_schema.json
@@ -283,8 +283,13 @@
       "description": "A parameter is a value that can be passed to an executable and all of its sub-executables.\nOnly one of `text`, `secretRef`, `prompt`, or `file` must be set. Specifying more than one will result in an error.\n",
       "type": "object",
       "properties": {
+        "envFile": {
+          "description": "A path to a file containing environment variables to be passed to the executable.\nThe file should contain one variable per line in the format `KEY=VALUE`.\n",
+          "type": "string",
+          "default": ""
+        },
         "envKey": {
-          "description": "The name of the environment variable that will be assigned the value.",
+          "description": "The name of the environment variable that will be assigned the value.\n\nWhen specified with `envFile`, only the environment variable with this name will be set.\n",
           "type": "string",
           "default": ""
         },

--- a/docs/schemas/workspace_schema.json
+++ b/docs/schemas/workspace_schema.json
@@ -60,6 +60,14 @@
       "type": "string",
       "default": ""
     },
+    "envFiles": {
+      "description": "A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables.\nBy default, the `.env` file in the workspace root is loaded if it exists.\n",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "executables": {
       "$ref": "#/definitions/ExecutableFilter"
     },

--- a/docs/types/flowfile.md
+++ b/docs/types/flowfile.md
@@ -237,7 +237,8 @@ Only one of `text`, `secretRef`, `prompt`, or `file` must be set. Specifying mor
 
 | Field | Description | Type | Default | Required |
 | ----- | ----------- | ---- | ------- | :--------: |
-| `envKey` | The name of the environment variable that will be assigned the value. | `string` |  |  |
+| `envFile` | A path to a file containing environment variables to be passed to the executable. The file should contain one variable per line in the format `KEY=VALUE`.  | `string` |  |  |
+| `envKey` | The name of the environment variable that will be assigned the value.  When specified with `envFile`, only the environment variable with this name will be set.  | `string` |  |  |
 | `outputFile` | A path where the parameter value will be temporarily written to disk. The file will be created before execution and cleaned up afterwards.  | `string` |  |  |
 | `prompt` | A prompt to be displayed to the user when collecting an input value. | `string` |  |  |
 | `secretRef` | A reference to a secret to be passed to the executable. | `string` |  |  |

--- a/docs/types/workspace.md
+++ b/docs/types/workspace.md
@@ -17,6 +17,7 @@ Every workspace has a workspace config file named `flow.yaml` in the root of the
 | `description` | A description of the workspace. This description is rendered as markdown in the interactive UI. | `string` |  |  |
 | `descriptionFile` | A path to a markdown file that contains the description of the workspace. | `string` |  |  |
 | `displayName` | The display name of the workspace. This is used in the interactive UI. | `string` |  |  |
+| `envFiles` | A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables. By default, the `.env` file in the workspace root is loaded if it exists.  | `array` (`string`) | [] |  |
 | `executables` |  | [ExecutableFilter](#ExecutableFilter) | <no value> |  |
 | `tags` |  | [CommonTags](#CommonTags) | [] |  |
 | `verbAliases` |  | [VerbAliases](#VerbAliases) | <no value> |  |

--- a/internal/mcp/resources/flowfile_schema.json
+++ b/internal/mcp/resources/flowfile_schema.json
@@ -283,8 +283,13 @@
       "description": "A parameter is a value that can be passed to an executable and all of its sub-executables.\nOnly one of `text`, `secretRef`, `prompt`, or `file` must be set. Specifying more than one will result in an error.\n",
       "type": "object",
       "properties": {
+        "envFile": {
+          "description": "A path to a file containing environment variables to be passed to the executable.\nThe file should contain one variable per line in the format `KEY=VALUE`.\n",
+          "type": "string",
+          "default": ""
+        },
         "envKey": {
-          "description": "The name of the environment variable that will be assigned the value.",
+          "description": "The name of the environment variable that will be assigned the value.\n\nWhen specified with `envFile`, only the environment variable with this name will be set.\n",
           "type": "string",
           "default": ""
         },

--- a/internal/mcp/resources/workspace_schema.json
+++ b/internal/mcp/resources/workspace_schema.json
@@ -60,6 +60,14 @@
       "type": "string",
       "default": ""
     },
+    "envFiles": {
+      "description": "A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables.\nBy default, the `.env` file in the workspace root is loaded if it exists.\n",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "executables": {
       "$ref": "#/definitions/ExecutableFilter"
     },

--- a/tests/exec_cmd_e2e_test.go
+++ b/tests/exec_cmd_e2e_test.go
@@ -4,6 +4,8 @@ package tests_test
 
 import (
 	stdCtx "context"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,6 +70,23 @@ var _ = Describe("exec e2e", func() {
 			Expect(out).To(ContainSubstring("argval"))
 			Expect(out).NotTo(ContainSubstring("notme"))
 
+			Expect(out).To(ContainSubstring("flow completed"))
+		})
+	})
+
+	Describe("workspace envFile feature", func() {
+		It("should inherit environment variables from workspace .env file", func() {
+			envFilePath := filepath.Join(ctx.WorkspaceDir(), ".env")
+			envContent := "WORKSPACE_ENV_VAR=test_value_from_env"
+			err := os.WriteFile(envFilePath, []byte(envContent), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			runner := utils.NewE2ECommandRunner()
+			stdOut := ctx.StdOut()
+			Expect(runner.Run(ctx.Context, "exec", "examples:with-workspace-env", "--log-level", "debug")).To(Succeed())
+			out, _ := readFileContent(stdOut)
+
+			Expect(out).To(ContainSubstring("WORKSPACE_ENV_VAR=test_value_from_env"))
 			Expect(out).To(ContainSubstring("flow completed"))
 		})
 	})

--- a/tests/utils/builder/exec.go
+++ b/tests/utils/builder/exec.go
@@ -237,3 +237,20 @@ func ExecWithEnvOutputFiles(opts ...Option) *executable.Executable {
 	}
 	return e
 }
+
+func ExecWithWorkspaceEnv(opts ...Option) *executable.Executable {
+	name := "with-workspace-env"
+	e := &executable.Executable{
+		Verb:       "run",
+		Name:       name,
+		Visibility: privateExecVisibility(),
+		Exec: &executable.ExecExecutableType{
+			Cmd: fmt.Sprintf(`echo 'hello from %s'; echo "WORKSPACE_ENV_VAR=$WORKSPACE_ENV_VAR"`, name),
+		},
+	}
+	if len(opts) > 0 {
+		vals := NewOptionValues(opts...)
+		e.SetContext(vals.WorkspaceName, vals.WorkspacePath, vals.NamespaceName, vals.FlowFilePath)
+	}
+	return e
+}

--- a/tests/utils/builder/flowfile.go
+++ b/tests/utils/builder/flowfile.go
@@ -34,6 +34,7 @@ func ExamplesExecFlowFile(opts ...Option) *executable.FlowFile {
 			ExecWithLogMode(opts...),
 			ExecWithTimeout(opts...),
 			ExecWithEnvOutputFiles(opts...),
+			ExecWithWorkspaceEnv(opts...),
 		},
 	}
 	if len(opts) > 0 {

--- a/types/executable/executable.gen.go
+++ b/types/executable/executable.gen.go
@@ -261,7 +261,17 @@ type ParallelRefConfigList []ParallelRefConfig
 // Only one of `text`, `secretRef`, `prompt`, or `file` must be set. Specifying
 // more than one will result in an error.
 type Parameter struct {
+	// A path to a file containing environment variables to be passed to the
+	// executable.
+	// The file should contain one variable per line in the format `KEY=VALUE`.
+	//
+	EnvFile string `json:"envFile,omitempty" yaml:"envFile,omitempty" mapstructure:"envFile,omitempty"`
+
 	// The name of the environment variable that will be assigned the value.
+	//
+	// When specified with `envFile`, only the environment variable with this name
+	// will be set.
+	//
 	EnvKey string `json:"envKey,omitempty" yaml:"envKey,omitempty" mapstructure:"envKey,omitempty"`
 
 	// A path where the parameter value will be temporarily written to disk.

--- a/types/executable/executable_schema.yaml
+++ b/types/executable/executable_schema.yaml
@@ -203,6 +203,12 @@ definitions:
         type: string
         description: A reference to a secret to be passed to the executable.
         default: ""
+      envFile:
+        type: string
+        description: |
+          A path to a file containing environment variables to be passed to the executable.
+          The file should contain one variable per line in the format `KEY=VALUE`.
+        default: ""
       outputFile:
         type: string
         description: |
@@ -211,7 +217,10 @@ definitions:
         default: ""
       envKey:
         type: string
-        description: The name of the environment variable that will be assigned the value.
+        description: |
+          The name of the environment variable that will be assigned the value.
+          
+          When specified with `envFile`, only the environment variable with this name will be set.
         default: ""
   ParameterList:
     type: array

--- a/types/workspace/schema.yaml
+++ b/types/workspace/schema.yaml
@@ -67,6 +67,14 @@ properties:
     goJSONSchema:
       type: "map[string][]string"
       nillable: false
+  envFiles:
+    type: array
+    items:
+      type: string
+    description: |
+      A list of environment variable files to load for the workspace. These files should contain key-value pairs of environment variables.
+      By default, the `.env` file in the workspace root is loaded if it exists.
+    default: []
   assignedName:
     type: string
     goJSONSchema:

--- a/types/workspace/workspace.gen.go
+++ b/types/workspace/workspace.gen.go
@@ -46,6 +46,12 @@ type Workspace struct {
 	// The display name of the workspace. This is used in the interactive UI.
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" mapstructure:"displayName,omitempty"`
 
+	// A list of environment variable files to load for the workspace. These files
+	// should contain key-value pairs of environment variables.
+	// By default, the `.env` file in the workspace root is loaded if it exists.
+	//
+	EnvFiles []string `json:"envFiles,omitempty" yaml:"envFiles,omitempty" mapstructure:"envFiles,omitempty"`
+
 	// Executables corresponds to the JSON schema field "executables".
 	Executables *ExecutableFilter `json:"executables,omitempty" yaml:"executables,omitempty" mapstructure:"executables,omitempty"`
 


### PR DESCRIPTION
This pull request adds support for loading environment variables from `.env` files at both the workspace and executable parameter levels. It introduces new configuration options, updates documentation and schemas, and includes comprehensive tests for the new functionality.