### PR TITLE
fix: environment variables should be expanded when ws dir prefix x is used

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -71,12 +71,11 @@ func ExpandPath(path, fallbackDir string, env map[string]string) string {
 // - all other paths -> delegated to ExpandPath
 // If the input contains a filename, returns just the directory portion.
 func ExpandDirectory(dir, wsPath, execPath string, env map[string]string) string {
-	var expandedPath string
+	expandedPath := dir
 	if wsPath != "" && strings.HasPrefix(dir, "//") {
-		expandedPath = strings.Replace(dir, "//", wsPath+"/", 1)
-	} else {
-		expandedPath = ExpandPath(dir, filepath.Dir(execPath), env)
+		expandedPath = strings.Replace(expandedPath, "//", wsPath+"/", 1)
 	}
+	expandedPath = ExpandPath(expandedPath, filepath.Dir(execPath), env)
 
 	if ext := filepath.Ext(expandedPath); ext != "" && !isHiddenDir(expandedPath) {
 		return filepath.Dir(expandedPath)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -62,6 +62,11 @@ var _ = Describe("Utils", func() {
 				Expect(utils.ExpandDirectory("/${VAR1}/${VAR2}", wsDir, execPath, envMap)).
 					To(Equal("/one/two"))
 			})
+			It("expands the env vars with a ws prefix", func() {
+				envMap := map[string]string{"VAR1": "one"}
+				Expect(utils.ExpandDirectory("//dir/${VAR1}", wsDir, execPath, envMap)).
+					To(Equal("/workspace/dir/one"))
+			})
 			It("logs a warning if the env var is not found", func() {
 				envMap := map[string]string{"VAR1": "one"}
 				mockLogger.EXPECT().Warnx("unable to find env key in path expansion", "key", "VAR2")


### PR DESCRIPTION
Small fix that prevents environment variable for directory / file path fields. When `//` is used as a prefix, expansion was previously being skipped.
