### PR TITLE
fix: launch uri respect app prefixes

### DIFF
--- a/internal/runner/launch/launch.go
+++ b/internal/runner/launch/launch.go
@@ -70,7 +70,7 @@ func (r *launchRunner) Exec(
 
 	launchSpec.URI = os.ExpandEnv(launchSpec.URI)
 	targetURI := launchSpec.URI
-	if !strings.HasPrefix(targetURI, "http") {
+	if !strings.Contains(targetURI, "://") {
 		targetURI = utils.ExpandDirectory(
 			launchSpec.URI,
 			e.WorkspacePath(),

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -42,7 +42,7 @@ func ExpandPath(path, fallbackDir string, env map[string]string) string {
 		} else {
 			targetPath = filepath.Join(homeDir, path[2:])
 		}
-	case strings.HasPrefix(path, "/"), strings.HasPrefix(path, "$"):
+	case strings.HasPrefix(path, "/"), strings.HasPrefix(path, "$"), strings.Contains(path, "://"):
 		targetPath = path
 	default:
 		targetPath = filepath.Join(fallbackDir, path)


### PR DESCRIPTION
Launch URIs that include the app's prefix should be respected and opened without expansion. For instance, a URI like `obsidian://open?vault=docs` should work
