### PR TITLE
fix: include ws in nameless refs with a ns

### DIFF
--- a/types/executable/executable.go
+++ b/types/executable/executable.go
@@ -523,7 +523,7 @@ func NewExecutableID(workspace, namespace, name string) string {
 	case ns == "" && name == "":
 		return ws + "/" // nameless executable
 	case ns != "" && name == "":
-		return fmt.Sprintf("%s:", ns)
+		return fmt.Sprintf("%s/%s:", ws, ns)
 	case ns != "":
 		return fmt.Sprintf("%s/%s:%s", ws, ns, name)
 	default:


### PR DESCRIPTION
Small fix where references for an executable with a namespace but no name resulted a ref like `exec ns:` instead of `exec ws/ns:`
