### PR TITLE
feat: visibility flag for browse cmd

### DIFF
--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -72,6 +72,13 @@ var FilterVerbFlag = &Metadata{
 	Required:  false,
 }
 
+var VisibilityFlag = &Metadata{
+	Name:     "visibility",
+	Usage:    "Filter by visibility level (hierarchical). Valid: public, private, internal, hidden. Default: private",
+	Default:  "",
+	Required: false,
+}
+
 var FilterTagFlag = &Metadata{
 	Name:      "tag",
 	Shorthand: "t",

--- a/docs/cli/flow_browse.md
+++ b/docs/cli/flow_browse.md
@@ -19,15 +19,16 @@ flow browse [EXECUTABLE-REFERENCE] [flags]
 ### Options
 
 ```
-  -a, --all                List from all namespaces.
-  -f, --filter string      Filter executable by reference substring.
-  -h, --help               help for browse
-  -l, --list               Show a simple list view of executables instead of interactive discovery.
-  -n, --namespace string   Filter executables by namespace.
-  -o, --output string      Output format. One of: yaml, json, or tui. (default "tui")
-  -t, --tag stringArray    Filter by tags.
-  -v, --verb string        Filter executables by verb.
-  -w, --workspace string   Filter executables by workspace.
+  -a, --all                 List from all namespaces.
+  -f, --filter string       Filter executable by reference substring.
+  -h, --help                help for browse
+  -l, --list                Show a simple list view of executables instead of interactive discovery.
+  -n, --namespace string    Filter executables by namespace.
+  -o, --output string       Output format. One of: yaml, json, or tui. (default "tui")
+  -t, --tag stringArray     Filter by tags.
+  -v, --verb string         Filter executables by verb.
+      --visibility string   Filter by visibility level (hierarchical). Valid: public, private, internal, hidden. Default: private
+  -w, --workspace string    Filter executables by workspace.
 ```
 
 ### Options inherited from parent commands

--- a/internal/io/library/init.go
+++ b/internal/io/library/init.go
@@ -75,7 +75,7 @@ func (l *Library) setVisibleExecs() {
 	filter := l.filter
 	filteredExec := l.allExecutables
 	filteredExec = filteredExec.
-		FilterByWorkspace(curWs).
+		FilterByWorkspaceWithVisibility(curWs, filter.Visibility).
 		FilterByNamespace(curNs).
 		FilterByVerb(filter.Verb).
 		FilterByTags(filter.Tags).

--- a/internal/io/library/library.go
+++ b/internal/io/library/library.go
@@ -48,6 +48,7 @@ type Filter struct {
 	Verb                 executable.Verb
 	Tags                 common.Tags
 	Substring            string
+	Visibility           common.Visibility
 }
 
 func NewLibrary(

--- a/types/common/common.go
+++ b/types/common/common.go
@@ -73,3 +73,22 @@ func (v Visibility) IsInternal() bool {
 func (v Visibility) IsHidden() bool {
 	return v == VisibilityHidden
 }
+
+// Level returns the hierarchical level of the visibility for filtering comparisons.
+// Hierarchy (most to least visible):
+// 1: public, 2: private, 3: internal, 4: hidden
+// Defaults to private when unknown.
+func (v Visibility) Level() int {
+	switch v {
+	case VisibilityPublic:
+		return 1
+	case VisibilityPrivate:
+		return 2
+	case VisibilityInternal:
+		return 3
+	case VisibilityHidden:
+		return 4
+	default:
+		return 2
+	}
+}


### PR DESCRIPTION
Add support for filtering executables by visibility. This will allow the inclusion of internal and hidden executables in the output when the flag is set to those values. The returned executables use a hierarchical match instead of exact (i.e. internal will also return private and public)