### PR TITLE
fix: exec name alias should be respected when ws verb aliases are set

### DIFF
--- a/internal/cache/executables_cache_test.go
+++ b/internal/cache/executables_cache_test.go
@@ -270,6 +270,13 @@ var _ = Describe("ExecutableCacheImpl", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(exec).NotTo(BeNil())
 				Expect(exec.Name).To(Equal("test-alias"))
+
+				// And should still be able to access via name alias using the primary verb
+				aliasRunRef := executable.Ref("run test/testdata:alias1")
+				execFromAlias, err := execCache.GetExecutableByRef(aliasRunRef)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(execFromAlias).NotTo(BeNil())
+				Expect(execFromAlias.Name).To(Equal("test-alias"))
 			})
 		})
 


### PR DESCRIPTION
Fixes a bug where an executable's alias is not being added to the cache when the workspace has verb overrides set.