### PR TITLE
chore: bump go verion

### DIFF
--- a/.execs/tools.flow
+++ b/.execs/tools.flow
@@ -28,7 +28,7 @@ executables:
         - cmd: |
             if ! command -v golangci-lint &> /dev/null; then
               echo "golangci-lint is not installed. Installing..."
-              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.2.2
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.5.0
             fi
         - cmd: |
             if ! command -v ginkgo &> /dev/null; then

--- a/.execs/validate.flow
+++ b/.execs/validate.flow
@@ -56,7 +56,7 @@ executables:
         - cmd: |
             if ! command -v golangci-lint &> /dev/null; then
               echo "Installing golangci-lint..."
-              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.1.6
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.5.0
               export PATH="$PATH:./bin"
             fi
             

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - uses: flowexec/action@v1
         with:
           executable: 'lint go --param CI=true'
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - uses: flowexec/action@v1
         with:
           executable: 'test unit --param CI=true'
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - uses: flowexec/action@v1
         with:
           executable: 'test e2e --param CI=true'
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@v0.4.0
       - uses: flowexec/action@v1
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - uses: flowexec/action@v1
         with:
           executable: 'build binary'
@@ -151,7 +151,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - uses: flowexec/action@v1
         with:
           executable: 'scan security'

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - name: Generate docs
         run: |
           go run ./tools/docsgen/.
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.24"
+          go-version: "^1.25"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -103,6 +103,10 @@ linters:
           - funlen
           - gocognit
           - gocyclo
+      # TODO: switch exec.Command usage to CommandContext
+      - linters:
+          - noctx
+        text: "os/exec.Command must not be called. use os/exec.CommandContext"
     paths:
       - third_party$
       - builtin$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ flow/
 ## Key Technologies & Frameworks
 
 ### Go CLI Application
-- **Language**: Go 1.24+ (see go.mod:3)
+- **Language**: Go 1.25+ (see go.mod:3)
 - **CLI Framework**: Cobra (github.com/spf13/cobra)
 - **TUI Framework**: Custom tuikit (github.com/flowexec/tuikit) based on github.com/charmbracelet/bubbletea 
 - **Testing**: Ginkgo BDD framework (github.com/onsi/ginkgo/v2)
@@ -84,14 +84,14 @@ The project heavily uses code generation:
 ## Configuration Files
 
 - **flow.yaml**: Workspace configuration for the flow repo itself
-- **go.mod**: Go dependencies and version (Go 1.24+)
+- **go.mod**: Go dependencies and version (Go 1.25+)
 - **desktop/package.json**: Node.js dependencies for desktop app
 - **desktop/src-tauri/tauri.conf.json**: Tauri desktop app configuration
 - **.execs/**: flow development workflows (executables)
 
 ## Development Setup
 
-1. **Prerequisites**: Go 1.24+, flow CLI installed
+1. **Prerequisites**: Go 1.25+, flow CLI installed
 2. **Setup**: `flow workspace add flow . --set`
 3. **Dependencies**: `flow install tools`
 4. **Verification**: `flow validate`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.1-bookworm
+FROM golang:1.25.2-bookworm
 
 ENV DISABLE_FLOW_INTERACTIVE="true"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flowexec/flow
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
# Summary

Bumps the project to Go version `1.25` which also requires using a newer `golanglint-ci`
