### PR TITLE
fix(mcp): reply instead of hanging when a command exits non-zero

### DIFF
--- a/internal/mcp/command_executor.go
+++ b/internal/mcp/command_executor.go
@@ -134,8 +134,15 @@ func (c *FlowCLIExecutor) ExecuteContext(ctx context.Context, args ...string) (s
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// Only return an error if it's not an exit error.
-		var exitErr exec.ExitError
+		// Only return an error if it's not an exit error: a non-zero exit is a
+		// normal outcome whose detail is already in the captured output.
+		//
+		// The target must be *exec.ExitError, not exec.ExitError. ExitError's
+		// Error method has a pointer receiver, so the value type does not
+		// implement error and errors.As panics on it - which killed the tool
+		// handler's goroutine before it could reply, leaving the MCP client
+		// waiting on a request that never got a response.
+		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
 			return string(output), err
 		}

--- a/internal/mcp/command_executor_internal_test.go
+++ b/internal/mcp/command_executor_internal_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeFlowBinary writes a script that echoes to both streams and exits with the
+// given code, then points FLOW_CLI_BINARY at it so FlowCLIExecutor runs it in
+// place of the real CLI.
+func fakeFlowBinary(t *testing.T, exitCode int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script stand-in is not portable to Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "fake-flow")
+	script := "#!/bin/sh\necho stdout-line\necho stderr-line >&2\nexit " +
+		strings.TrimSpace(string(rune('0'+exitCode))) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatalf("writing fake binary: %v", err)
+	}
+	t.Setenv(cliBinaryEnvKey, path)
+}
+
+// A non-zero exit is a normal outcome for a flow command (a failing test, a
+// script that raises). It must come back as output with a nil error, not as a
+// panic: a panic here kills the tool handler's goroutine before it replies, and
+// the MCP client then waits on a request that never gets a response.
+func TestExecuteContext_NonZeroExitReturnsOutputNotPanic(t *testing.T) {
+	fakeFlowBinary(t, 1)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ExecuteContext panicked on a non-zero exit: %v", r)
+		}
+	}()
+
+	out, err := (&FlowCLIExecutor{}).ExecuteContext(context.Background(), "anything")
+	if err != nil {
+		t.Errorf("err = %v, want nil for a non-zero exit", err)
+	}
+	if !strings.Contains(out, "stdout-line") || !strings.Contains(out, "stderr-line") {
+		t.Errorf("output = %q, want both streams captured", out)
+	}
+}
+
+func TestExecuteContext_SuccessReturnsOutput(t *testing.T) {
+	fakeFlowBinary(t, 0)
+
+	out, err := (&FlowCLIExecutor{}).ExecuteContext(context.Background(), "anything")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !strings.Contains(out, "stdout-line") {
+		t.Errorf("output = %q, want stdout captured", out)
+	}
+}
+
+// A missing binary is a real failure, not an exit status, so it must surface as
+// an error rather than being swallowed alongside exit codes.
+func TestExecuteContext_MissingBinaryReturnsError(t *testing.T) {
+	t.Setenv(cliBinaryEnvKey, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	if _, err := (&FlowCLIExecutor{}).ExecuteContext(context.Background(), "anything"); err == nil {
+		t.Error("err = nil, want an error when the binary cannot be run")
+	}
+}


### PR DESCRIPTION
**Part 1/2.** Base: `main`. Independent of the Python stack (#439–#443).

# Summary

Any MCP tool call whose `flow` subprocess exited non-zero left the client waiting on a request that **never got a response**, until it hit an idle timeout. A failing test, a script that raises, an executable that is not found — each one hung the agent instead of reporting the failure.

`internal/mcp/command_executor.go` passed a *value* to `errors.As`:

```go
var exitErr exec.ExitError        // value
if !errors.As(err, &exitErr) {    // panics
```

`ExitError.Error()` has a pointer receiver, so `exec.ExitError` does not implement `error`, and `errors.As` panics on such a target — `errors: *target must be interface or implement error`. That panic killed the tool handler's goroutine before it could reply.

The fix is `*exec.ExitError`, matching `tests/utils/runner.go:35`, which already had it right. That was the only other occurrence in the repo.

**Notable Changes**

- Restores the behavior the comment always described: a non-zero exit is a normal outcome whose detail is already in the captured output, so it returns as output with a `nil` error. Real failures (binary missing, context cancelled) still surface as errors.
- Affects every tool that shells out: `execute`, `run_command`, `run_executable`, `get_execution_logs`, `sync_executables`, and `write_flowfile`'s post-write sync.

# Why it was invisible

Nothing looked wrong from outside the process:

- The subprocess **had already run and finished** — `flow logs` showed the run recorded with its terminal `failed` status and error message, about a second in.
- No child or grandchild process was left running while the call still hung, so nothing was blocked on I/O.
- The server kept answering other requests instantly (`get_info` responded while the call was stuck) — only the one request was lost, so it read as a slow command rather than a crash.

The existing MCP tests all use a mocked `CommandExecutor`, so none of them ever exercised the real exit path.

# Testing

- New `TestExecuteContext_NonZeroExitReturnsOutputNotPanic` drives the **real** `FlowCLIExecutor` against a stand-in binary via `FLOW_CLI_BINARY`. Verified it fails with the original panic when the fix is reverted, and passes with it.
- Plus success-path and missing-binary cases, so the "swallow exit errors, surface real ones" split is pinned.
- `flow validate` passes (generate → lint → unit + e2e → schema validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R328pa3FUUfga4gYah1iQi