### PR TITLE
ci: run tasks with the flow binary under review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,17 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        run: go build -o ./bin/flow .
       - uses: flowexec/action@v1
         with:
           executable: 'lint go'
           params: 'CI=true'
           timeout: '5m'
+          flow-binary: ./bin/flow
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4.37.3
@@ -42,11 +48,17 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        run: go build -o ./bin/flow .
       - uses: flowexec/action@v1
         with:
           executable: 'test unit'
           params: 'CI=true'
           timeout: '5m'
+          flow-binary: ./bin/flow
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
         id: unit-tests
       - name: Upload unit test coverage
@@ -63,11 +75,17 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        run: go build -o ./bin/flow .
       - uses: flowexec/action@v1
         with:
           executable: 'test e2e'
           params: 'CI=true'
           timeout: '10m'
+          flow-binary: ./bin/flow
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
           secrets: |
             test-secret=test-value-from-action
@@ -111,16 +129,24 @@ jobs:
           go-version: "1.25.x"
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@v0.4.0
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        run: go build -o ./bin/flow .
       - uses: flowexec/action@v1
         with:
           executable: 'generate'
           timeout: '10m'
+          flow-binary: ./bin/flow
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
       - name: Check for uncommitted changes
         uses: flowexec/action@v1
         with:
           executable: 'validate generated'
           timeout: '2m'
+          flow-binary: ./bin/flow
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
 
   build-matrix:
@@ -134,14 +160,24 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI. The
+      # bootstrap binary lives in ./bin; `build binary` writes its own to .bin.
+      - name: Build flow
+        shell: bash
+        run: go build -o ./bin/${{ runner.os == 'Windows' && 'flow.exe' || 'flow' }} .
       - uses: flowexec/action@v1
         with:
           executable: 'build binary'
+          flow-binary: ./bin/${{ runner.os == 'Windows' && 'flow.exe' || 'flow' }}
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
           timeout: '10m'
       - uses: flowexec/action@v1
         with:
           executable: 'test binary'
+          flow-binary: ./bin/${{ runner.os == 'Windows' && 'flow.exe' || 'flow' }}
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
           timeout: '5m'
 
@@ -153,10 +189,16 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.25.x"
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        run: go build -o ./bin/flow .
       - uses: flowexec/action@v1
         with:
           executable: 'scan security'
           timeout: '10m'
+          flow-binary: ./bin/flow
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: 'main'
       - name: Upload govuln SARIF file
         uses: github/codeql-action/upload-sarif@v4.37.3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,12 +26,19 @@ jobs:
         with:
           go-version: "1.25.x"
           cache: true
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        shell: bash
+        run: go build -o ./bin/flow.exe .
       - name: Run unit tests
         uses: flowexec/action@v1
         with:
           executable: "test unit"
           params: "CI=true"
           timeout: "5m"
+          flow-binary: ./bin/flow.exe
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: "main"
       - name: Upload unit test coverage
         if: always()
@@ -53,12 +60,19 @@ jobs:
         with:
           go-version: "1.25.x"
           cache: true
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        shell: bash
+        run: go build -o ./bin/flow.exe .
       - name: Run E2E tests
         uses: flowexec/action@v1
         with:
           executable: "test e2e"
           params: "CI=true"
           timeout: "10m"
+          flow-binary: ./bin/flow.exe
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: "main"
           secrets: |
             test-secret=test-value-from-action
@@ -112,11 +126,18 @@ jobs:
         with:
           name: windows-flow-binary
           path: .bin
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        shell: bash
+        run: go build -o ./bin/flow.exe .
       - name: Run binary smoke test
         uses: flowexec/action@v1
         with:
           executable: "test binary"
           timeout: "5m"
+          flow-binary: ./bin/flow.exe
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: "main"
 
   native-scripts:
@@ -132,11 +153,18 @@ jobs:
         with:
           go-version: "1.25.x"
           cache: true
+      # Build the flow under review and run every task with it, so CI exercises
+      # the code as it would land on main rather than the released CLI.
+      - name: Build flow
+        shell: bash
+        run: go build -o ./bin/flow.exe .
       - name: Run .bat and .ps1 file execution tests
         uses: flowexec/action@v1
         with:
           executable: "test windows-scripts"
           timeout: "5m"
+          flow-binary: ./bin/flow.exe
+          # Fallback for action releases predating flow-binary; drop once v1 includes it.
           flow-version: "main"
 
   windows-validation-complete:


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on flowexec/action#2. Until that lands and `v1` moves, the `flow-binary` input is ignored and these jobs behave exactly as they do today (see *Merge order* below).

# Summary

Every CI job installed flow via `flowexec/action` with `flow-version: main`, which clones flow from GitHub and builds `main` — **discarding the branch under review**. CI validated each change with a flow that predated it.

Each job now builds flow first and passes it through:

```yaml
- name: Build flow
  run: go build -o ./bin/flow .
- uses: flowexec/action@v1
  with:
    executable: 'test unit'
    flow-binary: ./bin/flow
```

# Why it matters

For the Go-test jobs the gap is mostly benign — flow is only the task runner, and `go test` compiles the PR's code either way. It stops being benign as soon as a `.execs` target depends on a flow capability that has not shipped.

That is not hypothetical. #439 adds Python execution, and its `.execs` target failed on every platform:

```
Executing: flow test python-script
unable to parse file - 14:1: `foo(` must be followed by `)`
```

The released flow parsed the `.py` file as shell. **No change to that PR could have made the job pass** — the capability has to be on `main` before CI can use it, which is circular. The job there was reworked to build locally; this PR generalizes that to every job rather than leaving it a one-off.

# Merge order

`flow-version: 'main'` is deliberately **kept alongside** `flow-binary`, so this is safe to merge in either order:

| Action version | Behavior |
|---|---|
| With flowexec/action#2 | `flow-binary` wins → tasks run the PR's build ✅ |
| Without it | Input ignored, falls back to `flow-version: main` → today's behavior, CI stays green |

Without that fallback the input would be silently dropped and `flow-version` would default to `latest`, quietly changing which flow runs. The `flow-version` lines can be removed once `v1` carries the input.

# Notable Changes

- `ci.yaml`: `lint`, `unit-tests`, `e2e-tests`, `validate-generated`, `build-matrix`, `security`.
- `windows-ci.yml`: `unit-tests`, `e2e-tests`, `binary-smoke`, `native-scripts`.
- `build-matrix` names the binary per-OS (`flow.exe` on Windows) rather than relying on whether `go build -o` appends the extension. Its bootstrap lives in `./bin`; `build binary` still writes its own to `.bin`, so they do not collide.

# Deliberate exclusions

- **`windows-ci`'s `build-binary` job** keeps `flow-version: latest` — its whole purpose is to exercise the install script.
- **`release`, `container`, `release-docs`** are untouched. The same reasoning applies (arguably more so: a tag build should use the tagged code), but they publish artifacts and cannot be verified from a pull request. Worth a follow-up.

# Testing

Both workflow files parse as valid YAML. The end-to-end proof is this PR's own CI run once flowexec/action#2 is released — the step log should read `Using provided flow binary: ./bin/flow` instead of `Building flow from main branch...`.

Note this touches the same jobs as #439, which adds `setup-python` and a `python-scripts` job. Whichever merges second needs a rebase; the changes are complementary, not conflicting in intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R328pa3FUUfga4gYah1iQi