### PR TITLE
fix(runner): do not group a single task's output in CI

### DIFF
--- a/internal/runner/parallel/parallel.go
+++ b/internal/runner/parallel/parallel.go
@@ -268,7 +268,13 @@ func handleExec(
 	}
 
 	parentTask := ctx.CurrentTask
-	if parentTask == nil {
+	// Group the run's output only when there is more than one task. GitHub log
+	// groups are always collapsed, so wrapping a single task's output hides the
+	// only thing worth reading behind a click, with no structure gained.
+	// EndGroup is guarded by the same condition rather than relying on the
+	// logger to ignore an unmatched call, so this is correct on older tuikit too.
+	groupOutput := parentTask == nil && len(execs) > 1
+	if groupOutput {
 		if tal, ok := logger.Log().(io.TaskAwareLogger); ok {
 			tal.BeginGroup(parent.Ref().String())
 		}
@@ -283,7 +289,9 @@ func handleExec(
 		parentTask.Children = append(parentTask.Children, tracker.Tasks()...)
 	} else {
 		if tal, ok := logger.Log().(io.TaskAwareLogger); ok {
-			tal.EndGroup()
+			if groupOutput {
+				tal.EndGroup()
+			}
 			tal.PrintTaskSummary(tracker.Tasks())
 		}
 	}

--- a/internal/runner/serial/serial.go
+++ b/internal/runner/serial/serial.go
@@ -252,7 +252,13 @@ func handleExec(
 	}
 
 	parentTask := ctx.CurrentTask
-	if parentTask == nil {
+	// Group the run's output only when there is more than one task. GitHub log
+	// groups are always collapsed, so wrapping a single task's output hides the
+	// only thing worth reading behind a click, with no structure gained.
+	// EndGroup is guarded by the same condition rather than relying on the
+	// logger to ignore an unmatched call, so this is correct on older tuikit too.
+	groupOutput := parentTask == nil && len(execs) > 1
+	if groupOutput {
 		if tal, ok := logger.Log().(io.TaskAwareLogger); ok {
 			tal.BeginGroup(parent.Ref().String())
 		}
@@ -263,7 +269,9 @@ func handleExec(
 		parentTask.Children = append(parentTask.Children, tracker.Tasks()...)
 	} else {
 		if tal, ok := logger.Log().(io.TaskAwareLogger); ok {
-			tal.EndGroup()
+			if groupOutput {
+				tal.EndGroup()
+			}
 			tal.PrintTaskSummary(tracker.Tasks())
 		}
 	}


### PR DESCRIPTION
Companion to flowexec/tuikit#113 and flowexec/action#3.

# Summary

A serial or parallel executable wrapped its whole run in a GitHub log group named after the ref. GitHub log groups are **always collapsed**, and there is no way to default one open — so a single-task run hid the only output worth reading behind a click, gaining no structure in exchange.

From a real CI run of `test unit`:

```
##[endgroup]
Executing: flow test unit --param CI=true
##[group]test flow/unit          ← everything below is collapsed
ok  github.com/flowexec/flow/v2/cmd/internal  1.271s
...
```

`test unit` is a serial executable with one step, so the group had exactly one child.

# Change

Emit the group only when there is more than one task:

```go
groupOutput := parentTask == nil && len(execs) > 1
```

`EndGroup` is guarded by the same condition rather than relying on the logger to ignore an unmatched call, so this is correct against the currently pinned tuikit (v0.4.1) as well as the version that hardens it.

# Verified

Built and run with `CI=true GITHUB_ACTIONS=true`:

| Case | Before | After |
|---|---|---|
| `flow test unit` (1 step) | `::group::test flow/unit` — all output collapsed | no group, output visible |
| serial, 2 steps | grouped | `::group::run flow/many` … `::endgroup::` — unchanged |
| parallel, 1 step | grouped | no group |
| parallel, 2+ steps | grouped | unchanged |

`flow validate` passes.

# Related

- flowexec/tuikit#113 — stops emitting GitHub-only `::group::` syntax on other CI providers, prevents invalid nested groups, and makes an unmatched `EndGroup` a no-op. Independent of this PR, but it is what makes the guard above belt-and-braces rather than load-bearing.
- flowexec/action#3 — prints the stderr the action was discarding, and adds a step summary plus a real error message in the failure annotation, so a failure is visible on the run page without expanding any log at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R328pa3FUUfga4gYah1iQi