### PR TITLE
chore: bump dependencies (consolidated)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           timeout: '5m'
           flow-version: 'main'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4.37.3
+        uses: github/codeql-action/upload-sarif@v4.37.4
         with:
           sarif_file: lint.sarif
           category: golangci-lint
@@ -159,6 +159,6 @@ jobs:
           timeout: '10m'
           flow-version: 'main'
       - name: Upload govuln SARIF file
-        uses: github/codeql-action/upload-sarif@v4.37.3
+        uses: github/codeql-action/upload-sarif@v4.37.4
         with:
           sarif_file: govuln.sarif

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,10 +24,10 @@ jobs:
         with:
           go-version: "1.25.x"
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.3
+        uses: github/codeql-action/init@v4.37.4
         with:
           languages: go
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.3
+        uses: github/codeql-action/autobuild@v4.37.4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.3
+        uses: github/codeql-action/analyze@v4.37.4

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2951,9 +2951,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3010,9 +3010,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3030,7 +3030,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260406091427-a791e22d5143
-	github.com/flowexec/tuikit v0.4.1
+	github.com/flowexec/tuikit v0.4.2
 	github.com/flowexec/vault v0.4.0
 	github.com/gen2brain/beeep v0.11.2
 	github.com/google/uuid v1.6.0
@@ -22,7 +22,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	go.etcd.io/bbolt v1.4.3
+	go.etcd.io/bbolt v1.5.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/esiqveland/notify v0.13.3 h1:QCMw6o1n+6rl+oLUfg8P1IIDSFsDEb2WlXvVvIJb
 github.com/esiqveland/notify v0.13.3/go.mod h1:hesw/IRYTO0x99u1JPweAl4+5mwXJibQVUcP0Iu5ORE=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/flowexec/tuikit v0.4.1 h1:c8qJtB0e8k8VnYnerwai/f4Gg8kkJTLE3fjsMRu619U=
-github.com/flowexec/tuikit v0.4.1/go.mod h1:NmuWfE/77Nj2qoyiH/4x1b5Ak1JOpL6HqpPEai38UHQ=
+github.com/flowexec/tuikit v0.4.2 h1:pXHZL7ihz31ofnVbkqDM+G5gFgYT+x30KLik7IHU4VA=
+github.com/flowexec/tuikit v0.4.2/go.mod h1:NmuWfE/77Nj2qoyiH/4x1b5Ak1JOpL6HqpPEai38UHQ=
 github.com/flowexec/vault v0.4.0 h1:ot52RkQr3C+mANg8V5OEtampS8zbgjg81CSQoshwOwg=
 github.com/flowexec/vault v0.4.0/go.mod h1:sjkvXBu/5+lJYEh2Gi+kRlVUGGrLItvITwpG6b0Q32o=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -229,8 +229,8 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
-go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
-go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
+go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
+go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=


### PR DESCRIPTION
Consolidates the three open dependabot PRs into one, plus a tuikit bump dependabot cannot open on its own.

# Summary

**Dependency bumps** (taken as-is from dependabot — closes #434, closes #435, closes #437):

| Dependency | From | To |
|---|---|---|
| `go.etcd.io/bbolt` | 1.4.3 | 1.5.0 |
| `github/codeql-action` | 4.37.3 | 4.37.4 |
| `postcss` (in `/docs`) | 8.5.12 | 8.5.25 |

**`github.com/flowexec/tuikit` 0.4.1 → 0.4.2** — [released](https://github.com/flowexec/tuikit/releases/tag/v0.4.2) for this change, so dependabot had nothing to open a PR against. It carries two logging fixes:

- `::group::` was emitted whenever `CI=true`. It is GitHub syntax, so every other provider (GitLab, CircleCI, Buildkite) printed literal `::group::name` lines instead of a header. Now gated on `GITHUB_ACTIONS`; other providers get the styled header that local runs already got.
- Nested groups and unmatched `EndGroup` calls could emit invalid output that swallowed or truncated the surrounding log — GitHub does not support nested groups, and a stray `::endgroup::` closes whatever it had open.

# Testing

`flow validate` passes — generate, lint, unit + e2e, generated-diff, schema validation.

**bbolt backs `pkg/store`**, so the suite was run against it rather than taking a minor bump on the datastore on trust. `pkg/store` and `pkg/cache` both pass.

**The tuikit fix was verified through this build**, not just assumed from the version number:

```
$ CI=true GITHUB_ACTIONS=true flow exec --spec '...serial with 2 steps...'
::group::run flow/many
::endgroup::

$ CI=true flow exec --spec '...same...'
(no literal workflow commands — was leaking them at v0.4.1)
```

# Related

flowexec/flow#448 stops flow from wrapping a *single* task's output in a group at all, which is the other half of making CI logs readable. It is independent of this PR — this one only moves the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R328pa3FUUfga4gYah1iQi
