### PR TITLE
fix(test): make container and store tests platform-aware on Windows

### DIFF
--- a/internal/runner/exec/exec_test.go
+++ b/internal/runner/exec/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	tuikitIO "github.com/flowexec/tuikit/io"
@@ -25,6 +26,17 @@ type runCall struct {
 	dir     string
 	envList []string
 	mode    tuikitIO.LogMode
+}
+
+// absHostVolumePath is an absolute host path valid on the current platform.
+// expandVolumeHost gates on filepath.IsAbs, which rejects a Unix-style path on
+// Windows - there an absolute path needs a drive letter. The container side of a
+// volume stays Unix, since container paths are always Linux paths.
+func absHostVolumePath() string {
+	if runtime.GOOS == "windows" {
+		return `C:\opt\data`
+	}
+	return "/opt/data"
 }
 
 func TestExec(t *testing.T) {
@@ -253,8 +265,11 @@ var _ = Describe("Exec Runner", func() {
 
 		It("expands and mounts workspace-relative and absolute volumes", func() {
 			c := &executable.ExecContainer{
-				Image:   "alpine:3",
-				Volumes: []executable.ExecContainerVolume{"//cache:/cache", "/opt/data:/data:ro"},
+				Image: "alpine:3",
+				Volumes: []executable.ExecContainerVolume{
+					"//cache:/cache",
+					executable.ExecContainerVolume(absHostVolumePath() + ":/data:ro"),
+				},
 			}
 			e := newContainerExec(c, executable.Directory(wsPath))
 			Expect(execRnr.Exec(ctx.Ctx, e, mockEngine, map[string]string{}, nil)).To(Succeed())
@@ -263,7 +278,7 @@ var _ = Describe("Exec Runner", func() {
 			// mounts[0] is the workspace; the two user volumes follow in order.
 			Expect(mounts[len(mounts)-2].HostPath).To(Equal(filepath.Join(wsPath, "cache")))
 			Expect(mounts[len(mounts)-2].ContainerPath).To(Equal("/cache"))
-			Expect(mounts[len(mounts)-1].HostPath).To(Equal("/opt/data"))
+			Expect(mounts[len(mounts)-1].HostPath).To(Equal(absHostVolumePath()))
 			Expect(mounts[len(mounts)-1].ContainerPath).To(Equal("/data"))
 			Expect(mounts[len(mounts)-1].Options).To(Equal("ro"))
 		})
@@ -306,7 +321,7 @@ var _ = Describe("Exec Runner", func() {
 				Expect(got).To(HaveSuffix(wantSuffix))
 			},
 			Entry("workspace-relative", "//sub/dir", false, filepath.Join("/ws/root", "sub", "dir")),
-			Entry("absolute", "/opt/data", false, "/opt/data"),
+			Entry("absolute", absHostVolumePath(), false, absHostVolumePath()),
 			Entry("home-relative", "~/thing", false, "thing"),
 			Entry("cwd-relative", "./local", false, "local"),
 			Entry("bare relative is rejected", "relative/path", true, ""),

--- a/internal/services/run/container_test.go
+++ b/internal/services/run/container_test.go
@@ -3,6 +3,7 @@ package run_test
 import (
 	"errors"
 	"os"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -132,7 +133,12 @@ var _ = Describe("Container backend", func() {
 
 			info, err := os.Stat(path)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(info.Mode().Perm()).To(Equal(os.FileMode(0600)))
+			// Unix permission bits are not expressible on Windows: Go maps them
+			// onto ACLs and the file reads back as 0666. The env file still holds
+			// secrets, so the mode is asserted everywhere it means something.
+			if runtime.GOOS != "windows" {
+				Expect(info.Mode().Perm()).To(Equal(os.FileMode(0600)))
+			}
 
 			content, err := os.ReadFile(path)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,7 +1,6 @@
 package store_test
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -22,7 +21,10 @@ var _ = Describe("BoltDataStore", func() {
 	var err error
 
 	BeforeEach(func() {
-		path := filepath.Join(GinkgoT().TempDir(), fmt.Sprintf("test_%s.db", GinkgoT().Name()))
+		// TempDir is already unique per spec, so the file needs no disambiguating
+		// suffix - and deriving one from the spec name broke on Windows, where a
+		// name containing "->" yields an illegal filename (ERROR_INVALID_NAME).
+		path := filepath.Join(GinkgoT().TempDir(), "test.db")
 		ds, err = store.NewDataStore(path)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds).NotTo(BeNil())


### PR DESCRIPTION
Unblocks the Windows check on #439. These failures are not from that PR — all four specs exist unchanged on `main`.

# Summary

Four specs asserted Unix-only behavior and failed on Windows. They have been latent for a while: `windows-ci` only runs behind the `test:windows` label, and no PR had carried it since the code that introduced them. Labelling #439 ran them for the first time.

| Spec | Why it failed on Windows |
|---|---|
| `expands and mounts workspace-relative and absolute volumes` | `/opt/data` is not absolute under `filepath.IsAbs` |
| `expands volume host paths [absolute]` | same |
| `writeEnvFile writes sorted 0600 entries` | mode read back as `0666` |
| `BoltDataStore` — **entire suite** | `ERROR_INVALID_NAME` in `BeforeEach` |

**Volume paths.** `expandVolumeHost` gates on `filepath.IsAbs`, which rejects `/opt/data` on Windows — there an absolute path needs a drive letter. Two specs hardcoded it as the *host* side of a volume. They now build the host path for the platform. The container side stays Unix, since container paths are always Linux paths, and `ExecContainerVolume.Parts` already handles the drive-letter colon.

**File mode.** Go maps Unix permission bits onto ACLs on Windows, so `0600` is not expressible and reads back as `0666`. The assertion is skipped there and still enforced everywhere it means something. The content assertion is unchanged.

**Store suite.** This one took out *every* spec in `pkg/store`, not just the offending one. The database filename was derived from the spec name:

```go
path := filepath.Join(GinkgoT().TempDir(), fmt.Sprintf("test_%s.db", GinkgoT().Name()))
```

One spec is named `... (running -> terminal)`, and `>` is not a legal Windows filename character — so `BeforeEach` failed with `ERROR_INVALID_NAME` (`0x7b`). `TempDir` is already unique per spec, so the suffix bought nothing and is dropped.

# Scope

**Test-only.** The production paths were already Windows-capable — `Parts` handles drive letters, and container paths are correctly validated with Unix semantics. This fixes assertions, not behavior.

# Testing

Verified on real Windows runners via `workflow_dispatch` rather than inferred from `GOOS` reasoning:

- **Before:** 3 failures (2 volume specs + `writeEnvFile`).
- **After the first fix:** those cleared, exposing the store suite failure underneath — which had been masked by the earlier ones.
- **After both:** all six Windows jobs green — unit, E2E, build, binary smoke, native script execution, validation.

Unix behavior is unchanged: `go test -tags=unit ./internal/runner/exec/ ./internal/services/run/ ./pkg/store/` passes locally, and the affected specs still assert the same things on Unix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R328pa3FUUfga4gYah1iQi
