### PR TITLE
ci: deploy docs as part of a dispatched release

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -1,9 +1,19 @@
 name: Docs
 
 on:
+  # Kept for a tag pushed by a human. A release cut through release.yaml pushes
+  # its tag with GITHUB_TOKEN, and GitHub does not start workflows from events
+  # that token creates - so release.yaml calls this workflow directly instead.
   push:
     tags:
       - "*"
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: false
+        default: 'production'
+        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -31,7 +41,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         uses: flowexec/action@v1
         with:
-          executable: "deploy docs:cloudflare ${{ github.event.inputs.environment || 'production' }}"
+          executable: "deploy docs:cloudflare ${{ inputs.environment || 'production' }}"
           timeout: '5m'
           flow-version: 'main'
           secrets: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,3 +61,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_FLOW_GITHUB_TOKEN: ${{ secrets.HOMEBREW_FLOW_GITHUB_TOKEN }}
+
+  # Publishing the docs is part of releasing: the site serves the JSON schemas
+  # that editors validate flowfiles against, so skipping it ships a release whose
+  # schema the world cannot see. This runs here rather than off the tag push
+  # because a tag pushed with GITHUB_TOKEN does not trigger workflows.
+  release-docs:
+    needs: release-binary
+    # Only for a dispatched release. A tag pushed by a human triggers
+    # release-docs.yaml on its own, and calling it here too would deploy twice.
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-docs.yaml
+    secrets: inherit


### PR DESCRIPTION
# Summary

The published JSON schemas at `flowexec.io` have been **stale since 2026-05-02**. Editors validate flowfiles against that URL, so anyone authoring a `container:` block today gets an "unknown property" warning — for a feature that merged 2026-07-22 (#407), with two releases shipping since.

```
$ curl -s https://flowexec.io/schemas/flowfile_schema.json | grep -c '"container"'
0
$ git show origin/main:docs/public/schemas/flowfile_schema.json | grep -c '"container"'
1
```

# Root cause

`release-docs.yaml` only listens on `push: tags`. Releases stopped arriving that way:

```
2026-08-03  release.yaml  workflow_dispatch  ref=main    ← v2.1.1
2026-07-26  release.yaml  workflow_dispatch  ref=main    ← v2.1.0
2026-05-01  release.yaml  push               ref=v2.0.0  ← last tag-push release
```

A dispatched release creates the tag inside the workflow:

```yaml
- name: Create Tag
  run: |
    git tag ${{ inputs.tag }}
    git push origin ${{ inputs.tag }}
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

[GitHub does not start workflow runs from events created with `GITHUB_TOKEN`](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) — an anti-recursion rule. So the tag push is invisible to `release-docs.yaml`, and it simply never ran. Its last successful run was a manual dispatch on 2026-05-02, which is exactly where the published schema froze.

Nothing failed. There was no run at all, which is why this went unnoticed.

# Fix

`release-docs.yaml` gains `workflow_call`, and `release.yaml` calls it after the binary publishes — so the site is updated by the same run that cuts the release.

- **Guarded to dispatched releases only** (`if: github.event_name == 'workflow_dispatch'`). A tag pushed by a human still triggers `release-docs.yaml` directly, and calling it in both paths would deploy twice, concurrently.
- **`environment` now reads from `inputs`**, which is populated for both a call and a dispatch, rather than `github.event.inputs`, which is only set for a dispatch. A tag push has neither, so the `'production'` default still applies.

I chose this over pushing the tag with a PAT: that would make tag pushes trigger everything downstream, but costs a long-lived secret with write scope, and widens what any future workflow change can set off.

# Publishing the current schema

This fixes it going forward. It does **not** publish the schema that is already stale — that needs one manual `workflow_dispatch` of the Docs workflow (or the next release, which will now carry it). Worth doing sooner: flowexec/flow#439 adds an `interpreter` field that will otherwise land in the same invisible state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R328pa3FUUfga4gYah1iQi
